### PR TITLE
Make seed optional.

### DIFF
--- a/lib/xxhash.rb
+++ b/lib/xxhash.rb
@@ -2,11 +2,11 @@ require 'xxhash/version'
 require 'xxhash/xxhash'
 
 module XXhash
-  def self.xxh32(input, seed)
+  def self.xxh32(input, seed = 0)
     Internal.xxh32(input, seed)
   end
 
-  def self.xxh32_stream(io, seed, chunk_size = 32)
+  def self.xxh32_stream(io, seed = 0, chunk_size = 32)
     raise ArgumentError, 'first argument should be IO' if !io.is_a?(IO) && !io.is_a?(StringIO)
 
     hash = Internal::StreamingHash.new(seed)

--- a/test/xxhash_test.rb
+++ b/test/xxhash_test.rb
@@ -6,6 +6,10 @@ describe XXhash do
     assert_equal 2758658570, XXhash.xxh32('test', 123)
   end
 
+  it 'uses 0 (default value) if seed is not specified' do
+    assert_equal 1042293711, XXhash.xxh32('test')
+  end
+
   describe 'StreamingHash' do
     it 'rises ArgumentError if forst argument is not IO object' do
       assert_raises(ArgumentError) do


### PR DESCRIPTION
If seed is not specified, xxh32 and xxh32_stream will use 0 as default.
