### PR TITLE
Update README with new link to xxHash project home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## xxHash [![Build Status](https://travis-ci.org/nashby/xxhash.png?branch=master)](https://travis-ci.org/nashby/xxhash)
 
-Ruby wrapper for [xxHash](http://code.google.com/p/xxhash/)
+Ruby wrapper for [xxHash](https://github.com/Cyan4973/xxHash)
 
 ### Install
 


### PR DESCRIPTION
- Google code is shutting down, reference the version on Github instead.