### PR TITLE
Add ability to hash files by path directly

### DIFF
--- a/ext/xxhash/xxhash.h
+++ b/ext/xxhash/xxhash.h
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <errno.h>
 #include <ruby.h>
 #include "libxxhash.h"
 
@@ -17,12 +18,14 @@ typedef struct {
 typedef VALUE (ruby_method)();
 
 VALUE xxhash_xxh32(VALUE mod, VALUE input, VALUE seed);
+VALUE xxhash_xxh32_file(VALUE mod, VALUE filename, VALUE seed);
 void xxhash32_streaming_hash_free(xxhash_xxh32_t* state);
 VALUE xxhash32_streaming_hash_new(VALUE klass, VALUE seed);
 VALUE xxhash32_streaming_hash_update(VALUE self, VALUE data);
 VALUE xxhash32_streaming_hash_reset(VALUE self);
 VALUE xxhash32_streaming_hash_digest(VALUE self);
 VALUE xxhash_xxh64(VALUE mod, VALUE input, VALUE seed);
+VALUE xxhash_xxh64_file(VALUE mod, VALUE filename, VALUE seed);
 void xxhash64_streaming_hash_free(xxhash_xxh64_t* state);
 VALUE xxhash64_streaming_hash_new(VALUE klass, VALUE seed);
 VALUE xxhash64_streaming_hash_update(VALUE self, VALUE data);

--- a/lib/xxhash.rb
+++ b/lib/xxhash.rb
@@ -11,6 +11,14 @@ module XXhash
     XXhashInternal.xxh64(input.to_s, seed.to_i)
   end
 
+  def self.xxh32_file(filename, seed = 0)
+    XXhashInternal.xxh32_file(filename.to_s, seed.to_i)
+  end
+
+  def self.xxh64_file(filename, seed = 0)
+    XXhashInternal.xxh64_file(filename.to_s, seed.to_i)
+  end
+
   def self.xxh32_stream(io, seed = 0, chunk_size = 32)
     seed = seed.to_i
     chunk_size = chunk_size.to_i

--- a/test/xxhash_test.rb
+++ b/test/xxhash_test.rb
@@ -17,13 +17,33 @@ describe XXhash do
     assert_equal 2758658570, XXhash.xxh32('test', 123)
   end
 
+  it 'returns 32-bit hash from a file' do
+    assert_equal XXhash.xxh32(File.read(__FILE__)), XXhash.xxh32_file(__FILE__)
+    assert_equal XXhash.xxh32(File.read(__FILE__), 123), XXhash.xxh32_file(__FILE__, 123)
+  end
+
   it 'returns 64-bit hash' do
     assert_equal 3134990500624303823, XXhash.xxh64('test', 123)
+  end
+
+  it 'returns 64-bit hash from a file' do
+    assert_equal XXhash.xxh64(File.read(__FILE__)), XXhash.xxh64_file(__FILE__)
+    assert_equal XXhash.xxh64(File.read(__FILE__), 123), XXhash.xxh64_file(__FILE__, 123)
   end
 
   it 'uses 0 (default value) if seed is not specified' do
     assert_equal 1042293711, XXhash.xxh32('test')
     assert_equal 5754696928334414137, XXhash.xxh64('test')
+  end
+
+  it 'raises an Errno exception for invalid file' do
+    assert_raises Errno::ENOENT do
+      XXhash.xxh32_file('nonexistent-file')
+    end
+
+    assert_raises Errno::ENOENT do
+      XXhash.xxh64_file('nonexistent-file')
+    end
   end
 
   describe 'XXhashInternal::StreamingHash32' do


### PR DESCRIPTION
This PR avoids costly ruby-related operations to directly hash a file on disk by path. Example benchmark below using the `Gemfile.lock` from this repository:

```ruby
Benchmark.bmbm do |x|
  str = File.read('Gemfile.lock')
  x.report('xxh64_file') {
    100_000.times { XXhash.xxh64_file('Gemfile.lock') }
  }
  x.report('xxh64_fread') {
    100_000.times { XXhash.xxh64(File.read('Gemfile.lock')) }
  }
end

#                   user     system      total        real
# xxh64_file    0.266867   0.979831   1.246698 (  1.251667)
# xxh64_fread   0.664015   1.241238   1.905253 (  1.911548)

```