### PR TITLE
Modernize Ruby C API ussage

### DIFF
--- a/ext/xxhash/xxhash.c
+++ b/ext/xxhash/xxhash.c
@@ -67,12 +67,29 @@ VALUE xxhash_xxh32(VALUE mod, VALUE input, VALUE seed)
   return ULL2NUM(XXH32(StringValuePtr(input), (size_t)RSTRING_LEN(input), (unsigned int)NUM2ULL(seed)));
 }
 
-void xxhash32_streaming_hash_free(xxhash_xxh32_t* storage)
+static void xxhash32_streaming_hash_free(void *ptr)
 {
+  xxhash_xxh32_t* storage = (xxhash_xxh32_t*)ptr;
   // Digest frees the memory.
   XXH32_freeState(storage->state);
   xfree(storage);
 }
+
+static size_t xxhash32_streaming_hash_memsize(const void *ptr)
+{
+  // Ideally we'd include sizeof(XXH32_state_t) too, but the type is opaque.
+  return sizeof(xxhash_xxh32_t);
+}
+
+static const rb_data_type_t xxhash_xxh32_type = {
+    .wrap_struct_name = "xxhash/xxhash32_streaming_hash",
+    .function = {
+        .dmark = NULL,
+        .dfree = xxhash32_streaming_hash_free,
+        .dsize = xxhash32_streaming_hash_memsize,
+    },
+    .flags = RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY
+};
 
 VALUE xxhash32_streaming_hash_new(VALUE klass, VALUE seed)
 {
@@ -86,14 +103,14 @@ VALUE xxhash32_streaming_hash_new(VALUE klass, VALUE seed)
     rb_raise(rb_eRuntimeError, "Error during reset.");
     return Qnil;
   }
-  return Data_Wrap_Struct(klass, 0, xxhash32_streaming_hash_free, storage);
+  return TypedData_Wrap_Struct(klass, &xxhash_xxh32_type, storage);
 }
 
 VALUE xxhash32_streaming_hash_reset(VALUE self)
 {
   XXH_errorcode code;
   xxhash_xxh32_t* storage;
-  Data_Get_Struct(self, xxhash_xxh32_t, storage);
+  TypedData_Get_Struct(self, xxhash_xxh32_t, &xxhash_xxh32_type, storage);
 
   code = XXH32_reset(storage->state, storage->seed);
   if(code != XXH_OK) {
@@ -107,7 +124,7 @@ VALUE xxhash32_streaming_hash_update(VALUE self, VALUE data)
 {
   XXH_errorcode code;
   xxhash_xxh32_t* storage;
-  Data_Get_Struct(self, xxhash_xxh32_t, storage);
+  TypedData_Get_Struct(self, xxhash_xxh32_t, &xxhash_xxh32_type, storage);
 
   code = XXH32_update(storage->state, StringValuePtr(data), (size_t)RSTRING_LEN(data));
   if(code != XXH_OK) {
@@ -119,7 +136,7 @@ VALUE xxhash32_streaming_hash_update(VALUE self, VALUE data)
 VALUE xxhash32_streaming_hash_digest(VALUE self)
 {
   xxhash_xxh32_t* storage;
-  Data_Get_Struct(self, xxhash_xxh32_t, storage);
+  TypedData_Get_Struct(self, xxhash_xxh32_t, &xxhash_xxh32_type, storage);
 
   // Do not free memory now.
   return ULL2NUM(XXH32_digest(storage->state));
@@ -130,12 +147,29 @@ VALUE xxhash_xxh64(VALUE mod, VALUE input, VALUE seed)
   return ULL2NUM(XXH64(StringValuePtr(input), (size_t)RSTRING_LEN(input), (unsigned int)NUM2ULL(seed)));
 }
 
-void xxhash64_streaming_hash_free(xxhash_xxh64_t* storage)
+static void xxhash64_streaming_hash_free(void *ptr)
 {
+  xxhash_xxh64_t* storage = (xxhash_xxh64_t*)ptr;
   // Digest frees the memory.
   XXH64_freeState(storage->state);
   xfree(storage);
 }
+
+static size_t xxhash64_streaming_hash_memsize(const void *ptr)
+{
+  // Ideally we'd include sizeof(XXH64_state_t) too, but the type is opaque.
+  return sizeof(xxhash_xxh64_t);
+}
+
+static const rb_data_type_t xxhash_xxh64_type = {
+    .wrap_struct_name = "xxhash/xxhash64_streaming_hash",
+    .function = {
+        .dmark = NULL,
+        .dfree = xxhash64_streaming_hash_free,
+        .dsize = xxhash64_streaming_hash_memsize,
+    },
+    .flags = RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY
+};
 
 VALUE xxhash64_streaming_hash_new(VALUE klass, VALUE seed)
 {
@@ -150,14 +184,14 @@ VALUE xxhash64_streaming_hash_new(VALUE klass, VALUE seed)
     rb_raise(rb_eRuntimeError, "Error during reset.");
     return Qnil;
   }
-  return Data_Wrap_Struct(klass, 0, xxhash64_streaming_hash_free, storage);
+  return TypedData_Wrap_Struct(klass, &xxhash_xxh64_type, storage);
 }
 
 VALUE xxhash64_streaming_hash_reset(VALUE self)
 {
   XXH_errorcode code;
   xxhash_xxh64_t* storage;
-  Data_Get_Struct(self, xxhash_xxh64_t, storage);
+  TypedData_Get_Struct(self, xxhash_xxh64_t, &xxhash_xxh64_type, storage);
 
   code = XXH64_reset(storage->state, storage->seed);
   if(code != XXH_OK) {
@@ -170,7 +204,7 @@ VALUE xxhash64_streaming_hash_update(VALUE self, VALUE data)
 {
   XXH_errorcode code;
   xxhash_xxh64_t* storage;
-  Data_Get_Struct(self, xxhash_xxh64_t, storage);
+  TypedData_Get_Struct(self, xxhash_xxh64_t, &xxhash_xxh64_type, storage);
 
   code = XXH64_update(storage->state, StringValuePtr(data), (size_t)RSTRING_LEN(data));
   if(code != XXH_OK) {
@@ -182,7 +216,7 @@ VALUE xxhash64_streaming_hash_update(VALUE self, VALUE data)
 VALUE xxhash64_streaming_hash_digest(VALUE self)
 {
   xxhash_xxh64_t* storage;
-  Data_Get_Struct(self, xxhash_xxh64_t, storage);
+  TypedData_Get_Struct(self, xxhash_xxh64_t, &xxhash_xxh64_type, storage);
 
   // Do not free memory now.
   return ULL2NUM(XXH64_digest(storage->state));
@@ -209,6 +243,7 @@ void Init_xxhash(void)
   rb_define_singleton_method(mInternal, "xxh64_file", (ruby_method*) &xxhash_xxh64_file, 2);
 
   cStreamingHash = rb_define_class_under(mInternal, "StreamingHash32", rb_cObject);
+  rb_undef_alloc_func(cStreamingHash);
 
   rb_define_singleton_method(cStreamingHash, "new", (ruby_method*) &xxhash32_streaming_hash_new, 1);
   rb_define_method(cStreamingHash, "update", (ruby_method*) &xxhash32_streaming_hash_update, 1);
@@ -216,6 +251,7 @@ void Init_xxhash(void)
   rb_define_method(cStreamingHash, "reset", (ruby_method*) &xxhash32_streaming_hash_reset, 0);
 
   cStreamingHash64 = rb_define_class_under(mInternal, "StreamingHash64", rb_cObject);
+  rb_undef_alloc_func(cStreamingHash64);
 
   rb_define_singleton_method(cStreamingHash64, "new", (ruby_method*) &xxhash64_streaming_hash_new, 1);
   rb_define_method(cStreamingHash64, "update", (ruby_method*) &xxhash64_streaming_hash_update, 1);

--- a/ext/xxhash/xxhash.h
+++ b/ext/xxhash/xxhash.h
@@ -19,14 +19,12 @@ typedef VALUE (ruby_method)();
 
 VALUE xxhash_xxh32(VALUE mod, VALUE input, VALUE seed);
 VALUE xxhash_xxh32_file(VALUE mod, VALUE filename, VALUE seed);
-void xxhash32_streaming_hash_free(xxhash_xxh32_t* state);
 VALUE xxhash32_streaming_hash_new(VALUE klass, VALUE seed);
 VALUE xxhash32_streaming_hash_update(VALUE self, VALUE data);
 VALUE xxhash32_streaming_hash_reset(VALUE self);
 VALUE xxhash32_streaming_hash_digest(VALUE self);
 VALUE xxhash_xxh64(VALUE mod, VALUE input, VALUE seed);
 VALUE xxhash_xxh64_file(VALUE mod, VALUE filename, VALUE seed);
-void xxhash64_streaming_hash_free(xxhash_xxh64_t* state);
 VALUE xxhash64_streaming_hash_new(VALUE klass, VALUE seed);
 VALUE xxhash64_streaming_hash_update(VALUE self, VALUE data);
 VALUE xxhash64_streaming_hash_reset(VALUE self);


### PR DESCRIPTION
Convert the old `Data_` API calls into `TypedData`. This allows for write barriers, immediate free etc.

Also undefined the allocators of the Data classes to avoid a warning on recent rubies.